### PR TITLE
Fix checking the wrong player's permission when sending anti-cheat reports in-game

### DIFF
--- a/src/main/java/net/purelic/commons/listeners/PlayerViolationCommand.java
+++ b/src/main/java/net/purelic/commons/listeners/PlayerViolationCommand.java
@@ -38,7 +38,7 @@ public class PlayerViolationCommand implements Listener {
         }
 
         for (Player online : Bukkit.getOnlinePlayers()) {
-            Profile profile = Commons.getProfile(player);
+            Profile profile = Commons.getProfile(online);
 
             if (!profile.isMod()) continue;
 


### PR DESCRIPTION
closes #10 